### PR TITLE
Problem: use of async/tokio bits where necessary

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ name = "trunk"
 path = "src/main.rs"
 
 [dependencies]
+anyhow = "1.0.69"
+async-trait = "0.1.64"
 bollard = "0.14.0"
 clap = { version = "4.1.1", features = ["derive"] }
 futures-util = "0.3.26"
@@ -22,7 +24,7 @@ serde_json = "1.0.91"
 serde_yaml = "0.9.17"
 tar = "0.4.38"
 thiserror = "1.0.38"
-tokio = "1.26.0"
+tokio = { version = "1.26.0", features = ["rt","rt-multi-thread","macros"] }
 toml = "0.7.2"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,8 @@ serde_json = "1.0.91"
 serde_yaml = "0.9.17"
 tar = "0.4.38"
 thiserror = "1.0.38"
-tokio = { version = "1.26.0", features = ["rt","rt-multi-thread","macros"] }
+tokio = { version = "1.26.0", features = ["rt","rt-multi-thread","macros","sync"] }
+tokio-stream = "0.1.12"
 toml = "0.7.2"
 
 [dev-dependencies]

--- a/src/commands/build.rs
+++ b/src/commands/build.rs
@@ -1,5 +1,6 @@
 use super::SubCommand;
 use crate::commands::pgx::build_pgx;
+use async_trait::async_trait;
 use clap::Args;
 use std::path::Path;
 use toml::Table;
@@ -12,8 +13,9 @@ pub struct BuildCommand {
     output_path: String,
 }
 
+#[async_trait]
 impl SubCommand for BuildCommand {
-    fn execute(&self) {
+    async fn execute(&self) -> Result<(), anyhow::Error> {
         println!("Building from path {}", self.path);
         let path = Path::new(&self.path);
         if path.join("Cargo.toml").exists() {
@@ -22,10 +24,11 @@ impl SubCommand for BuildCommand {
             let dependencies = cargo_toml.get("dependencies").unwrap().as_table().unwrap();
             if dependencies.contains_key("pgx") {
                 println!("Detected that we are building a pgx extension");
-                build_pgx(path, &self.output_path);
-                return;
+                build_pgx(path, &self.output_path).await?;
+                return Ok(());
             }
         }
         println!("Did not understand what to build");
+        Ok(())
     }
 }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -1,11 +1,14 @@
 use super::SubCommand;
+use async_trait::async_trait;
 use clap::Args;
 
 #[derive(Args)]
 pub struct InstallCommand {}
 
+#[async_trait]
 impl SubCommand for InstallCommand {
-    fn execute(&self) {
-        println!("trunk install: not implemented")
+    async fn execute(&self) -> Result<(), anyhow::Error> {
+        println!("trunk install: not implemented");
+        Ok(())
     }
 }

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,8 +1,10 @@
+use async_trait::async_trait;
 pub mod build;
 pub mod install;
 mod pgx;
 pub mod publish;
 
+#[async_trait]
 pub trait SubCommand {
-    fn execute(&self);
+    async fn execute(&self) -> Result<(), anyhow::Error>;
 }

--- a/src/commands/pgx.rs
+++ b/src/commands/pgx.rs
@@ -1,6 +1,11 @@
-use futures_util::stream::StreamExt;
+use std::default::Default;
 use std::include_str;
+use std::io;
+use std::io::{ErrorKind, Write};
 use std::path::Path;
+
+use futures_util::stream::StreamExt;
+
 use tar::Header;
 use thiserror::Error;
 
@@ -8,7 +13,11 @@ use bollard::image::BuildImageOptions;
 use bollard::Docker;
 
 use bollard::models::BuildInfo;
-use std::default::Default;
+use hyper::Body;
+use tokio::sync::mpsc;
+use tokio::sync::mpsc::error::TrySendError;
+use tokio::task;
+use tokio_stream::wrappers::ReceiverStream;
 
 #[derive(Error, Debug)]
 pub enum PgxBuildError {
@@ -19,18 +28,91 @@ pub enum PgxBuildError {
     DockerError(#[from] bollard::errors::Error),
 }
 
+/// Sends a byte stream in chunks to [tokio::mpsc] channel
+///
+/// It implements [std::io::Write] so it can be used in a sync task
+pub(crate) struct ByteStream {
+    sender: mpsc::Sender<Result<Vec<u8>, io::Error>>,
+    buffer: Vec<u8>,
+}
+
+impl ByteStream {
+    /// Creates a new ByteStream
+    pub(crate) fn new() -> (
+        mpsc::Receiver<Result<Vec<u8>, io::Error>>,
+        mpsc::Sender<Result<Vec<u8>, io::Error>>,
+        Self,
+    ) {
+        let (sender, receiver) = mpsc::channel(1);
+        let stream = Self {
+            sender: sender.clone(),
+            buffer: Vec::new(),
+        };
+        (receiver, sender, stream)
+    }
+}
+
+impl Drop for ByteStream {
+    fn drop(&mut self) {
+        let _ = self.flush();
+    }
+}
+
+const BUFFER_SIZE: usize = 8192;
+
+impl Write for ByteStream {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.buffer.extend_from_slice(buf);
+        if self.buffer.len() > BUFFER_SIZE {
+            self.flush()?;
+        }
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        let mut message = std::mem::replace(&mut self.buffer, Vec::new());
+        loop {
+            match self.sender.try_send(Ok(message)) {
+                // Success
+                Ok(()) => return Ok(()),
+                // Retry
+                Err(TrySendError::Full(Ok(msg))) => message = msg,
+                // We never send errors, so this is unreachable
+                Err(TrySendError::Full(Err(_))) => unreachable!(),
+                // No longer need to send anything
+                Err(TrySendError::Closed(_)) => {
+                    return Err(std::io::Error::from(ErrorKind::BrokenPipe))
+                }
+            }
+        }
+    }
+}
+
 pub async fn build_pgx(path: &Path, _output_path: &str) -> Result<(), PgxBuildError> {
-    // your code for building a pgx extension goes here
     println!("Building pgx extension at path {}", &path.display());
     let dockerfile = include_str!("./pgx_builder/Dockerfile");
 
-    let mut tar = tar::Builder::new(Vec::new());
-    tar.append_dir_all(".", path)?;
+    let (receiver, sender, stream) = ByteStream::new();
+    // Making path owned so we can send it to the tarring task below without having to worry
+    // about the lifetime of the reference.
+    let path = path.to_owned();
+    task::spawn_blocking(move || {
+        let f = || {
+            let mut tar = tar::Builder::new(stream);
+            tar.append_dir_all(".", path)?;
 
-    let mut header = Header::new_gnu();
-    header.set_size(dockerfile.len() as u64);
-    header.set_cksum();
-    tar.append_data(&mut header, "Dockerfile", dockerfile.as_bytes())?;
+            let mut header = Header::new_gnu();
+            header.set_size(dockerfile.len() as u64);
+            header.set_cksum();
+            tar.append_data(&mut header, "Dockerfile", dockerfile.as_bytes())?;
+            Ok(())
+        };
+        match f() {
+            Ok(()) => (),
+            Err(err) => sender.try_send(Err(err)).map(|_| ()).unwrap_or_default(),
+        }
+        ()
+    });
 
     let options = BuildImageOptions {
         dockerfile: "Dockerfile",
@@ -40,7 +122,11 @@ pub async fn build_pgx(path: &Path, _output_path: &str) -> Result<(), PgxBuildEr
     };
 
     let docker = Docker::connect_with_local_defaults()?;
-    let mut image_build_stream = docker.build_image(options, None, Some(tar.into_inner()?.into()));
+    let mut image_build_stream = docker.build_image(
+        options,
+        None,
+        Some(Body::wrap_stream(ReceiverStream::new(receiver))),
+    );
 
     while let Some(next) = image_build_stream.next().await {
         match next {

--- a/src/commands/publish.rs
+++ b/src/commands/publish.rs
@@ -1,11 +1,14 @@
 use super::SubCommand;
+use async_trait::async_trait;
 use clap::Args;
 
 #[derive(Args)]
 pub struct PublishCommand {}
 
+#[async_trait]
 impl SubCommand for PublishCommand {
-    fn execute(&self) {
-        println!("trunk publish: not implemented")
+    async fn execute(&self) -> Result<(), anyhow::Error> {
+        println!("trunk publish: not implemented");
+        Ok(())
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,7 @@
 mod commands;
 
 use crate::commands::SubCommand;
+use async_trait::async_trait;
 use clap::{Parser, Subcommand};
 
 #[derive(Parser)]
@@ -18,17 +19,19 @@ enum SubCommands {
     Install(commands::install::InstallCommand),
 }
 
+#[async_trait]
 impl SubCommand for SubCommands {
-    fn execute(&self) {
+    async fn execute(&self) -> Result<(), anyhow::Error> {
         match self {
-            SubCommands::Build(cmd) => cmd.execute(),
-            SubCommands::Publish(cmd) => cmd.execute(),
-            SubCommands::Install(cmd) => cmd.execute(),
+            SubCommands::Build(cmd) => cmd.execute().await,
+            SubCommands::Publish(cmd) => cmd.execute().await,
+            SubCommands::Install(cmd) => cmd.execute().await,
         }
     }
 }
 
-fn main() {
+#[tokio::main]
+async fn main() {
     let cli = Cli::parse();
-    cli.command.execute();
+    cli.command.execute().await.unwrap();
 }


### PR DESCRIPTION
This will make the structure of the program really convoluted.
   
Solution: make the whole program async

While at it, I've converted tar creation to more of an async stream to avoid delays sending it to Docker and over-allocating memory.

Minor cleanup and quality-of-life improvements.
