### PR TITLE
Trunk install from registry

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ futures-util = "0.3.26"
 hyper = "0.14.24"
 rand = "0.8.5"
 read-write-pipe = "0.1.0"
+reqwest = "0.11.14"
 semver = "1.0.16"
 serde = { version = "1.0.153", features = ["derive"] }
 serde_json = "1.0.91"

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -155,7 +155,6 @@ async fn install(
     for entry in entries {
         let entry = entry?;
         let name = entry.path()?;
-        println!("{:?}", name);
         if entry.header().entry_type() == EntryType::file() && name == Path::new("manifest.json") {
             manifest.replace(serde_json::from_reader(entry)?);
         }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -17,8 +17,8 @@ pub struct InstallCommand {
     pg_config: Option<PathBuf>,
     #[arg(long = "file", short = 'f')]
     file: Option<PathBuf>,
-    #[arg(long = "extension_version")]
-    extension_version: String,
+    #[arg(long = "version", short = 'v')]
+    version: String,
     #[arg(long = "registry", short = 'r', default_value = "https://pgtrunk.io")]
     registry: String,
 }
@@ -97,11 +97,11 @@ impl SubCommand for InstallCommand {
             // curl --request GET --url 'http://localhost:8080/extensions/{self.name}/{self.version}/download'
             let response = reqwest::get(&format!(
                 "{}/extensions/{}/{}/download",
-                self.registry, self.name, self.extension_version
+                self.registry, self.name, self.version
             ))
             .await?;
             let response_body = response.text().await?;
-            println!("{:?}", response_body);
+            println!("response body: {:?}", response_body);
             return Ok(());
         }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use flate2::read::GzDecoder;
 use reqwest;
 use std::fs::File;
-use std::io::Seek;
+use std::io::{Cursor, Seek};
 use std::path::{Path, PathBuf};
 use tar::{Archive, EntryType};
 use tokio_task_manager::Task;
@@ -101,7 +101,12 @@ impl SubCommand for InstallCommand {
             ))
             .await?;
             let response_body = response.text().await?;
-            println!("response body: {:?}", response_body);
+            // TODO(ianstanton) We're writing the file to the files system at the moment.
+            //  Determine if this is the right approach.
+            let file_response = reqwest::get(response_body).await?;
+            let mut file = std::fs::File::create(format!("{}-{}.tar.gz", self.name, self.version))?;
+            let mut content = Cursor::new(file_response.bytes().await?);
+            std::io::copy(&mut content, &mut file)?;
             return Ok(());
         }
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -90,7 +90,7 @@ impl SubCommand for InstallCommand {
         println!("Using pkglibdir: {:?}", package_lib_dir);
         println!("Using sharedir: {:?}", sharedir);
 
-        // If file is specified...
+        // If file is specified
         if let Some(ref file) = self.file {
             let f = File::open(file)?;
 

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -5,7 +5,7 @@ use clap::Args;
 use flate2::read::GzDecoder;
 use reqwest;
 use std::fs::File;
-use std::io::{Seek};
+use std::io::Seek;
 use std::path::{Path, PathBuf};
 use tar::{Archive, EntryType};
 use tokio_task_manager::Task;
@@ -122,7 +122,7 @@ impl SubCommand for InstallCommand {
                 "{}/extensions/{}/{}/download",
                 self.registry, self.name, self.version
             ))
-                .await?;
+            .await?;
             let response_body = response.text().await?;
             let file_response = reqwest::get(response_body).await?;
             let bytes = file_response.bytes().await?;
@@ -139,7 +139,13 @@ impl SubCommand for InstallCommand {
     }
 }
 
-async fn install(mut input: File, extension_dir: PathBuf,  package_lib_dir: PathBuf, bitcode_dir: PathBuf, sharedir: PathBuf) -> Result<(), anyhow::Error> {
+async fn install(
+    mut input: File,
+    extension_dir: PathBuf,
+    package_lib_dir: PathBuf,
+    bitcode_dir: PathBuf,
+    sharedir: PathBuf,
+) -> Result<(), anyhow::Error> {
     // First pass: get to the manifest
     // Because we're going over entries with `Seek` enabled, we're not reading everything.
     let mut archive = Archive::new(&input);
@@ -150,9 +156,7 @@ async fn install(mut input: File, extension_dir: PathBuf,  package_lib_dir: Path
         let entry = entry?;
         let name = entry.path()?;
         println!("{:?}", name);
-        if entry.header().entry_type() == EntryType::file()
-            && name == Path::new("manifest.json")
-        {
+        if entry.header().entry_type() == EntryType::file() && name == Path::new("manifest.json") {
             manifest.replace(serde_json::from_reader(entry)?);
         }
     }

--- a/src/commands/install.rs
+++ b/src/commands/install.rs
@@ -90,7 +90,6 @@ impl SubCommand for InstallCommand {
         println!("Using pkglibdir: {:?}", package_lib_dir);
         println!("Using sharedir: {:?}", sharedir);
 
-
         // If file is specified...
         if let Some(ref file) = self.file {
             let f = File::open(file)?;
@@ -115,6 +114,8 @@ impl SubCommand for InstallCommand {
             };
             install(input, extension_dir, package_lib_dir, bitcode_dir, sharedir).await?;
         } else {
+            // If a file is not specified, then we will query the registry
+            // and download the latest version of the package
             // Using the reqwest crate, we will run the equivalent of this curl command:
             // curl --request GET --url 'http://localhost:8080/extensions/{self.name}/{self.version}/download'
             let response = reqwest::get(&format!(
@@ -125,7 +126,7 @@ impl SubCommand for InstallCommand {
             let response_body = response.text().await?;
             let file_response = reqwest::get(response_body).await?;
             let bytes = file_response.bytes().await?;
-            // Decompress tar.gz
+            // unzip the archive into a temporary file
             let gz = GzDecoder::new(&bytes[..]);
             let mut tempfile = tempfile::tempfile()?;
             use read_write_pipe::*;
@@ -135,12 +136,6 @@ impl SubCommand for InstallCommand {
             install(input, extension_dir, package_lib_dir, bitcode_dir, sharedir).await?;
         }
         Ok(())
-        // Else
-
-
-        // If a file is not specified, then we will query the registry
-        // and download the latest version of the package
-
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use tokio_task_manager::{Task, TaskManager};
 
 #[derive(Parser)]
 #[command(author, version, about, long_about = None)]
-#[command(propagate_version = true)]
+#[command(propagate_version = false)]
 struct Cli {
     #[command(subcommand)]
     command: SubCommands,


### PR DESCRIPTION
Allows for installing extension from remote trunk registry. Example:
`trunk install pgmq --version 0.2.1 --registry https://my-registry.com`