### PR TITLE
By default, install the latest version of an extension

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -122,7 +122,7 @@ impl SubCommand for InstallCommand {
             ))
             .await?;
             let response_body = response.text().await?;
-            println!("Downloading from: {}", response_body);
+            println!("Downloading from: {response_body}");
             let file_response = reqwest::get(response_body).await?;
             let bytes = file_response.bytes().await?;
             // unzip the archive into a temporary file

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -17,8 +17,8 @@ pub struct InstallCommand {
     pg_config: Option<PathBuf>,
     #[arg(long = "file", short = 'f')]
     file: Option<PathBuf>,
-    #[arg(long = "version", short = 'v')]
-    version: Option<String>,
+    #[arg(long = "version", short = 'v', default_value = "latest")]
+    version: String,
     #[arg(
         long = "registry",
         short = 'r',
@@ -48,10 +48,6 @@ pub enum InstallError {
 #[async_trait]
 impl SubCommand for InstallCommand {
     async fn execute(&self, _task: Task) -> Result<(), anyhow::Error> {
-        let mut version = "latest".to_string();
-        if self.version.is_some() {
-            version = self.version.clone().unwrap();
-        }
         let installed_pg_config = which::which("pg_config").ok();
         let pg_config = self
             .pg_config
@@ -115,10 +111,10 @@ impl SubCommand for InstallCommand {
             // If a file is not specified, then we will query the registry
             // and download the latest version of the package
             // Using the reqwest crate, we will run the equivalent of this curl command:
-            // curl --request GET --url 'http://localhost:8080/extensions/{self.name}/{version}/download'
+            // curl --request GET --url 'http://localhost:8080/extensions/{self.name}/{self.version}/download'
             let response = reqwest::get(&format!(
                 "{}/extensions/{}/{}/download",
-                self.registry, self.name, version
+                self.registry, self.name, self.version
             ))
             .await?;
             let response_body = response.text().await?;


### PR DESCRIPTION
```
    Finished dev [unoptimized + debuginfo] target(s) in 0.28s
     Running `target/debug/trunk install --registry 'https://trunk-registry.cdb-dev.com' pgmq`
...
Downloading from: https://cdb-plat-use1-dev-pgtrunkio.s3.amazonaws.com/extensions/pgmq/pgmq-0.2.1.tar.gz
Installing pgmq 0.2.1
...
```

Related, server-side change https://github.com/CoreDB-io/trunk/pull/43