### PR TITLE
Install dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 temp.sh
+.DS_Store
+**/.DS_Store

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -15,6 +15,7 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0.69"
+async-recursion = "1.0.4"
 async-trait = "0.1.64"
 bollard = "0.14.0"
 clap = { version = "4.1.1", features = ["derive"] }

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -12,6 +12,7 @@ use anyhow::anyhow;
 use reqwest::Url;
 use tar::{Archive, EntryType};
 use tokio_task_manager::Task;
+use async_recursion::async_recursion;
 
 #[derive(Args)]
 pub struct InstallCommand {
@@ -99,6 +100,8 @@ impl SubCommand for InstallCommand {
         Ok(())
     }
 }
+
+#[async_recursion]
 async fn install(
     name: String,
     version: &str,
@@ -195,6 +198,7 @@ async fn install_file(
 
     let mut dependencies_to_install: Vec<String> = Vec::new();
     let mut manifest: Option<Manifest> = None;
+    {
     let entries = archive.entries_with_seek()?;
     for this_entry in entries {
         let mut entry = this_entry?;
@@ -237,7 +241,7 @@ async fn install_file(
             entry.read_to_string(&mut control_file)?;
             dependencies_to_install = read_dependencies(&control_file);
         }
-    }
+    }}
     println!("Dependencies: {dependencies_to_install:?}");
     for dependency in dependencies_to_install {
         // check a control file is present in sharedir for each dependency
@@ -292,6 +296,7 @@ async fn install_file(
             );
             return Ok(());
         }
+
         let entries = archive.entries_with_seek()?;
         for entry in entries {
             let mut entry = entry?;


### PR DESCRIPTION
During install, read the control file. If dependencies are detected that are not already installed, then install them.

Does not handle the case of an extension in the trunk registry with a dependency that is not in the registry.