### PR TITLE
Validate API token on `trunk publish`

### DIFF
--- a/registry/migrations/20230505011559_extension_owners.sql
+++ b/registry/migrations/20230505011559_extension_owners.sql
@@ -1,0 +1,8 @@
+-- Add table extension_owners
+CREATE TABLE IF NOT EXISTS extension_owners (
+    extension_id INT4 NOT NULL,
+    owner_id VARCHAR NOT NULL,
+    created_at TIMESTAMP,
+    created_by VARCHAR,
+    deleted BOOL NOT NULL DEFAULT false
+);

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1,5 +1,75 @@
 {
   "db": "PostgreSQL",
+  "2aa8ecff6be8c81144a148b7186424971aba6c06382692a0b26e37b03d68bce8": {
+    "describe": {
+      "columns": [
+        {
+          "name": "id",
+          "ordinal": 0,
+          "type_info": "Int8"
+        },
+        {
+          "name": "user_id",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "token",
+          "ordinal": 2,
+          "type_info": "Bytea"
+        },
+        {
+          "name": "name",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 4,
+          "type_info": "Timestamp"
+        },
+        {
+          "name": "last_used_at",
+          "ordinal": 5,
+          "type_info": "Timestamp"
+        }
+      ],
+      "nullable": [
+        false,
+        true,
+        true,
+        true,
+        true,
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      }
+    },
+    "query": "SELECT *\n                FROM api_tokens\n                WHERE\n                    token = $1"
+  },
+  "3719346bfce71eddb52e9e1b3c86ba3f9381d730e8f3f349d348e2a314eddb60": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      }
+    },
+    "query": "SELECT user_id\n                FROM api_tokens\n                WHERE\n                    token = $1\n                AND user_id IS NOT NULL"
+  },
   "48a96a05f91d89cfd30f0cd3b119f0690a53d71d82ad9d40a5b0a07941fc31c9": {
     "describe": {
       "columns": [

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -1,5 +1,25 @@
 {
   "db": "PostgreSQL",
+  "12ce7de3da92187f4468a89f5e1795da2b0471f90373200a5870448dae264aa0": {
+    "describe": {
+      "columns": [
+        {
+          "name": "user_id",
+          "ordinal": 0,
+          "type_info": "Varchar"
+        }
+      ],
+      "nullable": [
+        true
+      ],
+      "parameters": {
+        "Left": [
+          "Bytea"
+        ]
+      }
+    },
+    "query": "SELECT user_id\n                FROM api_tokens\n                WHERE\n                    token = $1"
+  },
   "2aa8ecff6be8c81144a148b7186424971aba6c06382692a0b26e37b03d68bce8": {
     "describe": {
       "columns": [
@@ -50,25 +70,50 @@
     },
     "query": "SELECT *\n                FROM api_tokens\n                WHERE\n                    token = $1"
   },
-  "3719346bfce71eddb52e9e1b3c86ba3f9381d730e8f3f349d348e2a314eddb60": {
+  "3d97358d04299f979123dc42ac48c1dfa5bffb9f042288edd43d43a9c7fec68c": {
     "describe": {
       "columns": [
         {
-          "name": "user_id",
+          "name": "extension_id",
           "ordinal": 0,
+          "type_info": "Int4"
+        },
+        {
+          "name": "owner_id",
+          "ordinal": 1,
           "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamp"
+        },
+        {
+          "name": "created_by",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "deleted",
+          "ordinal": 4,
+          "type_info": "Bool"
         }
       ],
       "nullable": [
-        true
+        false,
+        false,
+        true,
+        true,
+        false
       ],
       "parameters": {
         "Left": [
-          "Bytea"
+          "Int4",
+          "Text"
         ]
       }
     },
-    "query": "SELECT user_id\n                FROM api_tokens\n                WHERE\n                    token = $1\n                AND user_id IS NOT NULL"
+    "query": "SELECT *\n                FROM extension_owners\n                WHERE\n                    extension_id = $1\n                    and owner_id = $2"
   },
   "48a96a05f91d89cfd30f0cd3b119f0690a53d71d82ad9d40a5b0a07941fc31c9": {
     "describe": {

--- a/registry/sqlx-data.json
+++ b/registry/sqlx-data.json
@@ -20,6 +20,50 @@
     },
     "query": "SELECT user_id\n                FROM api_tokens\n                WHERE\n                    token = $1"
   },
+  "248a5a4eece6a88e283e65a41eee6d11e9010ab4c2d815c7cc39cc09ae813a67": {
+    "describe": {
+      "columns": [
+        {
+          "name": "extension_id",
+          "ordinal": 0,
+          "type_info": "Int4"
+        },
+        {
+          "name": "owner_id",
+          "ordinal": 1,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "created_at",
+          "ordinal": 2,
+          "type_info": "Timestamp"
+        },
+        {
+          "name": "created_by",
+          "ordinal": 3,
+          "type_info": "Varchar"
+        },
+        {
+          "name": "deleted",
+          "ordinal": 4,
+          "type_info": "Bool"
+        }
+      ],
+      "nullable": [
+        false,
+        false,
+        true,
+        true,
+        false
+      ],
+      "parameters": {
+        "Left": [
+          "Int4"
+        ]
+      }
+    },
+    "query": "SELECT *\n                FROM extension_owners\n                WHERE\n                    extension_id = $1"
+  },
   "2aa8ecff6be8c81144a148b7186424971aba6c06382692a0b26e37b03d68bce8": {
     "describe": {
       "columns": [
@@ -414,6 +458,20 @@
       }
     },
     "query": "SELECT *\n                FROM versions\n                WHERE \n                    extension_id = $1\n                    and num = $2"
+  },
+  "95a4c5b00a8f9e776aa73eb4fb2763496a8d234402467c50ef4cc8e1777d82f8": {
+    "describe": {
+      "columns": [],
+      "nullable": [],
+      "parameters": {
+        "Left": [
+          "Int4",
+          "Varchar",
+          "Varchar"
+        ]
+      }
+    },
+    "query": "\n        INSERT INTO extension_owners(extension_id, owner_id, created_at, created_by)\n        VALUES ($1, $2, (now() at time zone 'utc'), $3)\n        "
   },
   "c9f6b97900ea30be7f940f72c7e20ab21cd00f5f5ef4e4e52c228e2b7e070e9b": {
     "describe": {

--- a/registry/src/errors.rs
+++ b/registry/src/errors.rs
@@ -26,8 +26,8 @@ pub enum ExtensionRegistryError {
     ResponseError(),
 
     /// an authorization error
-    #[error("authorization error")]
-    AuthorizationError(),
+    #[error("authorization error: {0}")]
+    AuthorizationError(String),
 
     /// a payload error
     #[error("payload error: {0}")]

--- a/registry/src/errors.rs
+++ b/registry/src/errors.rs
@@ -1,6 +1,7 @@
 //! Custom errors types for extension registry
 use actix_multipart::MultipartError;
 use actix_web::error;
+use actix_web::http::header::ToStrError;
 use aws_sdk_s3::error::SdkError;
 use aws_sdk_s3::operation::put_object::PutObjectError;
 use std::str::Utf8Error;
@@ -56,9 +57,12 @@ pub enum ExtensionRegistryError {
     #[error("put object error: {0}")]
     PutObjectError(#[from] SdkError<PutObjectError>),
 
-    #[error("bad request error: {0}")]
+    #[error("token error: {0}")]
     TokenError(String),
 
-    #[error("Byte error: {0}")]
+    #[error("byte error: {0}")]
     ByteError(#[from] Utf8Error),
+
+    #[error("to str error: {0}")]
+    ToStrError(#[from] ToStrError),
 }

--- a/registry/src/extensions.rs
+++ b/registry/src/extensions.rs
@@ -1,0 +1,35 @@
+use crate::errors::ExtensionRegistryError;
+use actix_web::web::Data;
+use sqlx::{Pool, Postgres};
+
+pub fn check_input(input: &str) -> Result<(), ExtensionRegistryError> {
+    let valid = input
+        .as_bytes()
+        .iter()
+        .all(|&c| c.is_ascii_alphanumeric() || c == b'_');
+    match valid {
+        true => Ok(()),
+        false => Err(ExtensionRegistryError::ResponseError()),
+    }
+}
+
+pub async fn add_extension_owner(
+    extension_id: i64,
+    user_id: String,
+    conn: Data<Pool<Postgres>>,
+) -> Result<(), ExtensionRegistryError> {
+    let mut tx = conn.begin().await?;
+    sqlx::query!(
+        "
+        INSERT INTO extension_owners(extension_id, owner_id, created_at, created_by)
+        VALUES ($1, $2, (now() at time zone 'utc'), $3)
+        ",
+        extension_id as i32,
+        user_id,
+        user_id
+    )
+    .execute(&mut tx)
+    .await?;
+    tx.commit().await?;
+    Ok(())
+}

--- a/registry/src/lib.rs
+++ b/registry/src/lib.rs
@@ -4,6 +4,7 @@ use sqlx::{ConnectOptions, Pool, Postgres};
 pub mod config;
 pub mod download;
 pub mod errors;
+pub mod extensions;
 pub mod routes;
 pub mod token;
 pub mod uploader;

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -16,7 +16,7 @@ use futures::TryStreamExt;
 use serde_json::{json, Value};
 use sqlx::{Pool, Postgres};
 
-const MAX_SIZE: usize = 262_144; // max payload size is 256k
+const MAX_SIZE: usize = 5000000 as usize; // max payload size is 5M
 
 /// Handles the `POST /extensions/new` route.
 /// Used by `trunk publish` to publish a new extension or to publish a new version of an
@@ -42,7 +42,7 @@ pub async fn publish(
             // limit max size of in-memory payload
             if (chunk.len()) > MAX_SIZE {
                 return Err(ExtensionRegistryError::from(error::ErrorBadRequest(
-                    "extension size is greater than 256k",
+                    "extension size is greater than 5M",
                 )));
             }
             if field.name() == "metadata" {

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -16,7 +16,7 @@ use futures::TryStreamExt;
 use serde_json::{json, Value};
 use sqlx::{Pool, Postgres};
 
-const MAX_SIZE: usize = 5000000 as usize; // max payload size is 5M
+const MAX_SIZE: usize = 5000000; // max payload size is 5M
 
 /// Handles the `POST /extensions/new` route.
 /// Used by `trunk publish` to publish a new extension or to publish a new version of an

--- a/registry/src/routes/extensions.rs
+++ b/registry/src/routes/extensions.rs
@@ -36,6 +36,8 @@ pub async fn publish(
     while let Some(mut field) = payload.try_next().await? {
         let headers = field.headers();
         let auth = headers.get(AUTHORIZATION).unwrap();
+        // Check if token exists and has an associated user
+
         if auth != cfg.auth_token {
             error!("Authorization error");
             return Err(AuthorizationError());
@@ -77,6 +79,7 @@ pub async fn publish(
     match exists {
         // TODO(ianstanton) Refactor into separate functions
         Some(exists) => {
+            // Check if user is owner of extension
             // Extension exists
             let mut tx = conn.begin().await?;
             let extension_id = exists.id;
@@ -142,6 +145,7 @@ pub async fn publish(
             tx.commit().await?;
         }
         None => {
+            // Associate new extension with owner
             // Else, create new record in extensions table
             let mut tx = conn.begin().await?;
             let id_row = sqlx::query!(

--- a/registry/src/token.rs
+++ b/registry/src/token.rs
@@ -20,6 +20,7 @@ pub async fn validate_token(
     token: &HeaderValue,
     conn: Data<Pool<Postgres>>,
 ) -> Result<String, ExtensionRegistryError> {
+    check_token_input(token.to_str()?)?;
     let mut tx = conn.begin().await?;
     // Check if token exists
     let token_exists = sqlx::query!(
@@ -69,8 +70,32 @@ fn generate_secure_alphanumeric_string(len: usize) -> String {
         .collect()
 }
 
+pub fn check_token_input(input: &str) -> Result<(), ExtensionRegistryError> {
+    let valid = input.as_bytes().iter().all(|&c| c.is_ascii_alphanumeric());
+    match valid {
+        true => Ok(()),
+        false => Err(ExtensionRegistryError::TokenError(
+            "API token should only contain ASCII alphanumeric characters".to_string(),
+        )),
+    }
+}
+
 #[test]
 fn test_generate() {
     let (plain, sha256) = generate_token();
     assert_eq!(sha256, sha2::Sha256::digest(plain.as_bytes()).as_slice());
+}
+
+#[test]
+fn test_check_token() {
+    let invalid = ";vBAfmrAa228VPYUnpPv5NdDWFXfkyh6I;";
+    let invalid_result = check_token_input(invalid);
+    assert!(matches!(
+        invalid_result,
+        Err(ExtensionRegistryError::TokenError(_))
+    ));
+
+    let valid = "vBAfmrAa228VPYUnpPv5NdDWFXfkyh6I";
+    let valid_result = check_token_input(valid);
+    assert!(matches!(valid_result, Ok(())))
 }

--- a/registry/src/token.rs
+++ b/registry/src/token.rs
@@ -1,4 +1,5 @@
 use rand::{distributions::Uniform, rngs::OsRng, Rng};
+use reqwest::header::HeaderValue;
 use sha2::Digest;
 
 const TOKEN_LENGTH: usize = 32;
@@ -8,6 +9,11 @@ pub fn generate_token() -> (String, Vec<u8>) {
     let plaintext = generate_secure_alphanumeric_string(TOKEN_LENGTH);
     let sha256 = hash(&plaintext);
     (plaintext, sha256)
+}
+
+// Validate token exists and has an associated user
+pub fn validate_token(token: &HeaderValue) -> Result<> {
+
 }
 
 fn hash(plaintext: &str) -> Vec<u8> {


### PR DESCRIPTION
Add logic for the registry to validate API tokens when users publish extensions. This checks:
- API token exists in the backend DB
- There is a user ID associated with the API token
- User ID associated with token is an owner of the extension
  ```
  [2023-05-05T14:45:17Z ERROR trunk_registry::routes::extensions] The user associated with this API token is not an owner of extension pg_tle
  ```
- If there is no owner for an existing extension, add the publisher as owner
  ```
  [2023-05-05T14:48:27Z INFO  trunk_registry::routes::extensions] The extension pg_tle has no owner. Adding <user-id> as an owner of this extension.
  ```
- If the extension is new, assign the publisher as an owner:
  ```
  [2023-05-05T16:48:42Z INFO  trunk_registry::routes::extensions] Adding <user-id> as an owner of new extension pg_tle.
  ```

Also increase max extension size to `5M`.