### PR TITLE
Add license files to extension packages

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "pg-trunk"
-version = "0.4.7"
+version = "0.4.8"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"
 homepage = "https://pgtrunk.io"
 license = "Apache-2.0"
 readme = "README.md"
-repository = "https://github.com/coredb-io/coredb"
+repository = "https://github.com/CoreDB-io/trunk"
 
 [[bin]]
 name = "trunk"
@@ -23,6 +23,7 @@ elf = "0.7.2"
 flate2 = "1.0.25"
 futures-util = "0.3.26"
 hyper = "0.14.24"
+ignore = "0.4.20"
 rand = "0.8.5"
 read-write-pipe = "0.1.0"
 reqwest = { version = "0.11.16", features = ["multipart"] }

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -63,11 +63,13 @@ pub async fn exec_in_container(
     docker: Docker,
     container_id: &str,
     command: Vec<&str>,
+    env: Option<Vec<&str>>,
 ) -> Result<String, anyhow::Error> {
     println!("Executing in container: {:?}", command.join(" "));
 
     let config = CreateExecOptions {
         cmd: Some(command),
+        env,
         attach_stdout: Some(true),
         attach_stderr: Some(true),
         ..Default::default()
@@ -150,6 +152,7 @@ pub async fn find_installed_extension_files(
         docker.clone(),
         container_id,
         vec!["pg_config", "--sharedir"],
+        None,
     )
     .await?;
     let sharedir = sharedir.trim();
@@ -158,6 +161,7 @@ pub async fn find_installed_extension_files(
         docker.clone(),
         container_id,
         vec!["pg_config", "--pkglibdir"],
+        None,
     )
     .await?;
     let pkglibdir = pkglibdir.trim();
@@ -357,13 +361,15 @@ pub async fn package_installed_extension_files(
     let extension_name = extension_name.to_owned();
     let extension_version = extension_version.to_owned();
 
-    let target_arch = exec_in_container(docker.clone(), container_id, vec!["uname", "-m"]).await?;
+    let target_arch =
+        exec_in_container(docker.clone(), container_id, vec!["uname", "-m"], None).await?;
     let target_arch = target_arch.trim().to_string();
 
     let sharedir = exec_in_container(
         docker.clone(),
         container_id,
         vec!["pg_config", "--sharedir"],
+        None,
     )
     .await?;
     let sharedir = sharedir.trim();
@@ -372,6 +378,7 @@ pub async fn package_installed_extension_files(
         docker.clone(),
         container_id,
         vec!["pg_config", "--pkglibdir"],
+        None,
     )
     .await?;
     let pkglibdir = pkglibdir.trim();

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -206,11 +206,45 @@ pub async fn find_installed_extension_files(
     for pkglibdir_file in pkglibdir_list.clone() {
         println!("\t{pkglibdir_file}");
     }
-    println!();
 
     let mut result = HashMap::new();
     result.insert("sharedir".to_string(), sharedir_list);
     result.insert("pkglibdir".to_string(), pkglibdir_list);
+    Ok(result)
+}
+
+pub async fn find_license_files(
+    docker: Docker,
+    container_id: &str,
+) -> Result<HashMap<String, Vec<String>>, anyhow::Error> {
+    let licensedir = "/usr/licenses/";
+
+    // collect changes from container filesystem
+    let changes = docker
+        .container_changes(container_id)
+        .await?
+        .expect("Expected to find changed files");
+
+    let mut licensedir_list = vec![];
+
+    for change in changes {
+        if change.path.starts_with(licensedir) {
+            let file_in_licensedir = change.path;
+            let file_in_licensedir = file_in_licensedir.strip_prefix(licensedir);
+            let file_in_licensedir = file_in_licensedir.unwrap();
+            let file_in_licensedir = file_in_licensedir.trim_start_matches('/');
+            licensedir_list.push(file_in_licensedir.to_owned());
+        }
+    }
+
+    println!("License files:");
+    for license_file in licensedir_list.clone() {
+        println!("\t{license_file}");
+    }
+    println!();
+
+    let mut result = HashMap::new();
+    result.insert("licensedir".to_string(), licensedir_list);
     Ok(result)
 }
 
@@ -343,12 +377,15 @@ pub async fn package_installed_extension_files(
     let pkglibdir = pkglibdir.trim();
 
     let extension_files = find_installed_extension_files(docker.clone(), container_id).await?;
+    let license_files = find_license_files(docker.clone(), container_id).await?;
 
+    let licensedir_list = license_files["licensedir"].clone();
     let sharedir_list = extension_files["sharedir"].clone();
     let pkglibdir_list = extension_files["pkglibdir"].clone();
 
     let pkglibdir = pkglibdir.to_owned();
     let sharedir = sharedir.to_owned();
+    let licensedir = "/usr/licenses".to_owned();
 
     // In this function, we open and work with .tar only, then we finalize the package with a .gz in a separate call
     let package_path = format!("{package_path}/{extension_name}-{extension_version}.tar.gz");
@@ -390,16 +427,18 @@ pub async fn package_installed_extension_files(
             // If we can get the file from the stream
             // Then we will handle packaging the file
             let path = entry.path()?.to_path_buf();
-            // Check if we found a file to package in pkglibdir
+            // Check if we found a file to package in pkglibdir, sharedir or licensedir
             let full_path = format!("/{}", path.to_str().unwrap_or(""));
             let trimmed = full_path
                 .trim_start_matches(&format!("{}/", pkglibdir.clone()))
                 .trim_start_matches(&format!("{}/", sharedir.clone()))
+                .trim_start_matches(&format!("{}/", licensedir.clone()))
                 .to_string();
             let pkglibdir_match = pkglibdir_list.contains(&trimmed);
             let sharedir_match = sharedir_list.contains(&trimmed);
+            let licensedir_match = licensedir_list.contains(&trimmed);
             // Check if we found a file to package
-            if !(sharedir_match || pkglibdir_match) {
+            if !(sharedir_match || pkglibdir_match || licensedir_match) {
                 continue;
             }
             if path.to_str() == Some("manifest.json") {
@@ -409,14 +448,16 @@ pub async fn package_installed_extension_files(
                 let root_path = Path::new("/");
                 let path = root_path.join(path);
                 let mut path = path.as_path();
-                // trim pkglibdir or sharedir from start of path
+                // trim pkglibdir, sharedir or licensedir from start of path
                 if path.to_string_lossy().contains(&pkglibdir) {
                     path = path.strip_prefix(format!("{}/", &pkglibdir))?;
                 } else if path.to_string_lossy().contains(&sharedir) {
                     path = path.strip_prefix(format!("{}/", &sharedir))?;
+                } else if path.to_string_lossy().contains(&licensedir) {
+                    path = path.strip_prefix(format!("{}/", &licensedir))?;
                 } else {
                     println!(
-                        "WARNING: Skipping file because it's not in sharedir or pkglibdir {:?}",
+                        "WARNING: Skipping file because it's not in sharedir, pkglibdir or licensedir {:?}",
                         &path
                     );
                     continue;

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -386,12 +386,12 @@ pub async fn package_installed_extension_files(
     let extension_files = find_installed_extension_files(docker.clone(), container_id).await?;
     let license_files = find_license_files(docker.clone(), container_id).await?;
 
-    let licensedir_list = license_files["licensedir"].clone();
     let sharedir_list = extension_files["sharedir"].clone();
     let pkglibdir_list = extension_files["pkglibdir"].clone();
+    let licensedir_list = license_files["licensedir"].clone();
 
-    let pkglibdir = pkglibdir.to_owned();
     let sharedir = sharedir.to_owned();
+    let pkglibdir = pkglibdir.to_owned();
     let licensedir = "/usr/licenses".to_owned();
 
     // In this function, we open and work with .tar only, then we finalize the package with a .gz in a separate call

--- a/cli/src/commands/containers.rs
+++ b/cli/src/commands/containers.rs
@@ -461,7 +461,7 @@ pub async fn package_installed_extension_files(
                 } else if path.to_string_lossy().contains(&sharedir) {
                     path = path.strip_prefix(format!("{}/", &sharedir))?;
                 } else if path.to_string_lossy().contains(&licensedir) {
-                    path = path.strip_prefix(format!("{}/", &licensedir))?;
+                    path = path.strip_prefix("/usr/")?;
                 } else {
                     println!(
                         "WARNING: Skipping file because it's not in sharedir, pkglibdir or licensedir {:?}",

--- a/cli/src/commands/generic_build.rs
+++ b/cli/src/commands/generic_build.rs
@@ -15,6 +15,7 @@ use tokio_task_manager::Task;
 use crate::commands::containers::{
     build_image, exec_in_container, package_installed_extension_files, run_temporary_container,
 };
+use crate::commands::license::find_licenses;
 
 #[derive(Error, Debug)]
 pub enum GenericBuildError {
@@ -76,6 +77,15 @@ pub async fn build_generic(
     build_args.insert("EXTENSION_NAME", extension_name);
     build_args.insert("EXTENSION_VERSION", extension_version);
 
+    // Search for license files to include
+    let licenses = find_licenses(path)?;
+    let mut trimmed_licenses: Vec<String> = Vec::new();
+    // Trim path prefix
+    for license in licenses {
+        let trimmed = license.trim_start_matches(&format!("{}/", path.to_str().unwrap()));
+        trimmed_licenses.push(trimmed.parse().unwrap());
+    }
+
     let image_name_prefix = "make_builder_".to_string();
 
     let docker = Docker::connect_with_local_defaults()?;
@@ -96,7 +106,38 @@ pub async fn build_generic(
 
     println!("Determining installation files...");
     let _exec_output =
-        exec_in_container(docker.clone(), &temp_container.id, install_command).await?;
+        exec_in_container(docker.clone(), &temp_container.id, install_command, None).await?;
+
+    println!("Determining license files to include...");
+    // Create directory /usr/licenses/
+    let _exec_output = exec_in_container(
+        docker.clone(),
+        &temp_container.id,
+        vec!["mkdir", "/usr/licenses/"],
+        None,
+    )
+    .await?;
+
+    // Iterate through license files and copy to /usr/licenses/. If filename exists in /usr/licenses,
+    // append numbered suffix. Example:
+    // ❯ tar -tvf .trunk/pg_stat_statements-1.10.0.tar.gz | grep -i copyright
+    //     -rw-r--r-- 0/0            4362 2023-05-15 19:28 COPYRIGHT
+    //     -rw-r--r-- 0/0            1192 2023-05-15 19:28 COPYRIGHT.~1~
+    for license in trimmed_licenses {
+        let _exec_output = exec_in_container(
+            docker.clone(),
+            &temp_container.id,
+            vec![
+                "cp",
+                "--backup",
+                "--verbose",
+                format!("{}", license).as_str(),
+                "/usr/licenses/",
+            ],
+            Some(vec!["VERSION_CONTROL=numbered"]),
+        )
+        .await?;
+    }
 
     // output_path is the locally output path
     fs::create_dir_all(output_path)?;

--- a/cli/src/commands/install.rs
+++ b/cli/src/commands/install.rs
@@ -345,6 +345,9 @@ async fn install_file(
                         println!("[+] {} => {}", name.display(), sharedir.display());
                         entry.unpack_in(&sharedir)?;
                     }
+                    PackagedFile::LicenseFile { .. } => {
+                        println!("Skipping license file {}", name.display());
+                    }
                 }
             }
         }

--- a/cli/src/commands/license.rs
+++ b/cli/src/commands/license.rs
@@ -1,11 +1,9 @@
 use anyhow::Error;
 use ignore::Error as IgnoreError;
-use std::{path::Path};
+use std::path::Path;
 use std::path::PathBuf;
 
-pub fn find_licenses(
-    directory: &Path,
-) -> Result<Vec<PathBuf>, Error> {
+pub fn find_licenses(directory: &Path) -> Result<Vec<PathBuf>, Error> {
     use ignore::types::TypesBuilder;
     use ignore::WalkBuilder;
 
@@ -21,7 +19,10 @@ pub fn find_licenses(
         .filter_map(|entry| match entry {
             Ok(entry) => Some(entry),
             Err(error) => {
-                IgnoreError::WithPath { path: Default::default(), err: Box::from(error) };
+                IgnoreError::WithPath {
+                    path: Default::default(),
+                    err: Box::from(error),
+                };
                 None
             }
         })

--- a/cli/src/commands/license.rs
+++ b/cli/src/commands/license.rs
@@ -1,0 +1,36 @@
+use anyhow::Error;
+use ignore::Error as IgnoreError;
+use std::{path::Path};
+use std::path::PathBuf;
+
+pub fn find_licenses(
+    directory: &Path,
+) -> Result<Vec<PathBuf>, Error> {
+    use ignore::types::TypesBuilder;
+    use ignore::WalkBuilder;
+
+    let mut types_builder = TypesBuilder::new();
+    types_builder.add_defaults();
+    types_builder.select("license");
+    let matcher = types_builder.build().unwrap();
+
+    let mut paths = Vec::new();
+    WalkBuilder::new(directory)
+        .types(matcher)
+        .build()
+        .filter_map(|entry| match entry {
+            Ok(entry) => Some(entry),
+            Err(error) => {
+                IgnoreError::WithPath { path: Default::default(), err: Box::from(error) };
+                None
+            }
+        })
+        .filter(|entry| !entry.metadata().unwrap().is_dir())
+        .for_each(|entry| {
+            let path = entry.path();
+            let path_owned = path.to_owned();
+            paths.push(path_owned);
+        });
+
+    Ok(paths)
+}

--- a/cli/src/commands/license.rs
+++ b/cli/src/commands/license.rs
@@ -1,9 +1,8 @@
 use anyhow::Error;
 use ignore::Error as IgnoreError;
 use std::path::Path;
-use std::path::PathBuf;
 
-pub fn find_licenses(directory: &Path) -> Result<Vec<PathBuf>, Error> {
+pub fn find_licenses(directory: &Path) -> Result<Vec<String>, Error> {
     use ignore::types::TypesBuilder;
     use ignore::WalkBuilder;
 
@@ -29,7 +28,7 @@ pub fn find_licenses(directory: &Path) -> Result<Vec<PathBuf>, Error> {
         .filter(|entry| !entry.metadata().unwrap().is_dir())
         .for_each(|entry| {
             let path = entry.path();
-            let path_owned = path.to_owned();
+            let path_owned = path.to_str().unwrap().to_owned();
             paths.push(path_owned);
         });
 

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -7,6 +7,7 @@ mod generic_build;
 pub mod install;
 mod pgrx;
 pub mod publish;
+pub mod license;
 
 #[async_trait]
 pub trait SubCommand {

--- a/cli/src/commands/mod.rs
+++ b/cli/src/commands/mod.rs
@@ -5,9 +5,9 @@ pub mod build;
 mod containers;
 mod generic_build;
 pub mod install;
+pub mod license;
 mod pgrx;
 pub mod publish;
-pub mod license;
 
 #[async_trait]
 pub trait SubCommand {

--- a/cli/src/commands/pgrx.rs
+++ b/cli/src/commands/pgrx.rs
@@ -16,6 +16,7 @@ use tokio::sync::mpsc;
 
 use tokio::task::JoinError;
 
+use crate::commands::license::find_licenses;
 use tokio_task_manager::Task;
 use toml::Value;
 
@@ -130,6 +131,14 @@ pub async fn build_pgrx(
         .ok_or(PgrxBuildError::ManifestError(
             "Could not find pgrx dependency info in Cargo.toml".to_string(),
         ))?;
+    // Search for license files to include
+    let licenses = find_licenses(path)?;
+    let mut trimmed_licenses: Vec<String> = Vec::new();
+    // Trim path prefix
+    for license in licenses {
+        let trimmed = license.trim_start_matches(&format!("{}/", path.to_str().unwrap()));
+        trimmed_licenses.push(trimmed.parse().unwrap());
+    }
 
     println!("Detected pgrx version range {}", &pgrx_range);
 
@@ -183,6 +192,30 @@ pub async fn build_pgrx(
         ],
     )
     .await?;
+
+    println!("Determining license files to include...");
+    // Create directory /usr/licenses/
+    let _exec_output = exec_in_container(
+        docker.clone(),
+        &temp_container.id,
+        vec!["mkdir", "/usr/licenses/"],
+    )
+    .await?;
+
+    // Iterate through license files and copy to /usr/licenses/
+    for license in trimmed_licenses {
+        let _exec_output = exec_in_container(
+            docker.clone(),
+            &temp_container.id,
+            vec![
+                "cp",
+                "--verbose",
+                format!("{}", license).as_str(),
+                "/usr/licenses/",
+            ],
+        )
+        .await?;
+    }
 
     // output_path is the locally output path
     fs::create_dir_all(output_path)?;

--- a/cli/src/commands/pgrx.rs
+++ b/cli/src/commands/pgrx.rs
@@ -190,6 +190,7 @@ pub async fn build_pgrx(
             format!("target/release/{extension_name}-pg15/usr").as_str(),
             "/",
         ],
+        None,
     )
     .await?;
 
@@ -199,20 +200,27 @@ pub async fn build_pgrx(
         docker.clone(),
         &temp_container.id,
         vec!["mkdir", "/usr/licenses/"],
+        None,
     )
     .await?;
 
-    // Iterate through license files and copy to /usr/licenses/
+    // Iterate through license files and copy to /usr/licenses/. If filename exists in /usr/licenses,
+    // append numbered suffix. Example:
+    // ❯ tar -tvf .trunk/pg_stat_statements-1.10.0.tar.gz | grep -i copyright
+    //     -rw-r--r-- 0/0            4362 2023-05-15 19:28 COPYRIGHT
+    //     -rw-r--r-- 0/0            1192 2023-05-15 19:28 COPYRIGHT.~1~
     for license in trimmed_licenses {
         let _exec_output = exec_in_container(
             docker.clone(),
             &temp_container.id,
             vec![
                 "cp",
+                "--backup",
                 "--verbose",
                 format!("{}", license).as_str(),
                 "/usr/licenses/",
             ],
+            Some(vec!["VERSION_CONTROL=numbered"]),
         )
         .await?;
     }

--- a/cli/src/manifest.rs
+++ b/cli/src/manifest.rs
@@ -11,11 +11,15 @@ pub enum PackagedFile {
     SharedObject {},
     Bitcode {},
     Extra {},
+    LicenseFile {},
 }
 
 impl PackagedFile {
     pub fn from<P: AsRef<Path>>(path: P) -> Self {
         let extension = path.as_ref().extension();
+        if path.as_ref().starts_with("licenses") {
+            return PackagedFile::LicenseFile {};
+        }
         if let Some(ext) = extension {
             match ext.to_str() {
                 Some("control") => PackagedFile::ControlFile {},

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -89,7 +89,7 @@ fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("LICENSE.txt"));
+    assert!(stdout.contains("licenses/LICENSE.txt"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 
@@ -147,8 +147,8 @@ fn build_c_extension() -> Result<(), Box<dyn std::error::Error>> {
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("LICENSE"));
-    assert!(stdout.contains("NOTICE"));
+    assert!(stdout.contains("licenses/LICENSE"));
+    assert!(stdout.contains("licenses/NOTICE"));
 
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
@@ -214,7 +214,7 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("LICENSE.md"));
+    assert!(stdout.contains("licenses/LICENSE.md"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 
@@ -284,8 +284,8 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
         .output()
         .expect("failed to run tar command");
     let stdout = String::from_utf8(output.stdout).unwrap();
-    assert!(stdout.contains("COPYRIGHT"));
-    assert!(stdout.contains("COPYRIGHT.~1~"));
+    assert!(stdout.contains("licenses/COPYRIGHT"));
+    assert!(stdout.contains("licenses/COPYRIGHT.~1~"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 

--- a/cli/tests/integration_tests.rs
+++ b/cli/tests/integration_tests.rs
@@ -82,6 +82,14 @@ fn build_pgrx_extension() -> Result<(), Box<dyn std::error::Error>> {
         format!("{output_dir}/test_pgrx_extension-0.0.0.tar.gz").as_str()
     )
     .exists());
+    // assert any license files are included
+    let output = Command::new("tar")
+        .arg("-tvf")
+        .arg(format!("{output_dir}/test_pgrx_extension-0.0.0.tar.gz").as_str())
+        .output()
+        .expect("failed to run tar command");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("LICENSE.txt"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 
@@ -132,6 +140,16 @@ fn build_c_extension() -> Result<(), Box<dyn std::error::Error>> {
     cmd.arg("pg_tle");
     cmd.assert().code(0);
     assert!(std::path::Path::new(format!("{output_dir}/pg_tle-1.0.3.tar.gz").as_str()).exists());
+    // assert any license files are included
+    let output = Command::new("tar")
+        .arg("-tvf")
+        .arg(format!("{output_dir}/pg_tle-1.0.3.tar.gz").as_str())
+        .output()
+        .expect("failed to run tar command");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("LICENSE"));
+    assert!(stdout.contains("NOTICE"));
+
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 
@@ -189,6 +207,14 @@ fn build_extension_custom_dockerfile() -> Result<(), Box<dyn std::error::Error>>
     cmd.arg("http");
     cmd.assert().code(0);
     assert!(std::path::Path::new(format!("{output_dir}/http-1.5.0.tar.gz").as_str()).exists());
+    // assert any license files are included
+    let output = Command::new("tar")
+        .arg("-tvf")
+        .arg(format!("{output_dir}/http-1.5.0.tar.gz").as_str())
+        .output()
+        .expect("failed to run tar command");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("LICENSE.md"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 
@@ -251,6 +277,15 @@ fn build_pg_stat_statements() -> Result<(), Box<dyn std::error::Error>> {
         std::path::Path::new(format!("{output_dir}/pg_stat_statements-1.10.tar.gz").as_str())
             .exists()
     );
+    // assert any license files are included
+    let output = Command::new("tar")
+        .arg("-tvf")
+        .arg(format!("{output_dir}/pg_stat_statements-1.10.tar.gz").as_str())
+        .output()
+        .expect("failed to run tar command");
+    let stdout = String::from_utf8(output.stdout).unwrap();
+    assert!(stdout.contains("COPYRIGHT"));
+    assert!(stdout.contains("COPYRIGHT.~1~"));
     // delete the temporary file
     std::fs::remove_dir_all(output_dir)?;
 

--- a/cli/tests/test_pgrx_extension/LICENSE.txt
+++ b/cli/tests/test_pgrx_extension/LICENSE.txt
@@ -1,0 +1,1 @@
+Test license file.


### PR DESCRIPTION
In this PR, we add a search for license files when a user runs `trunk build`. Any license files found are included in the extension's `tar.gz` file. Example:
```
Sharedir files:
	extension/pgmq--0.5.0.sql
	extension/pgmq.control
Pkglibdir files:
	pgmq.so
License files:
	LICENSE

Creating package at: ./.trunk/pgmq-0.5.0.tar.gz
Create Trunk bundle:
	pgmq.so
	LICENSE
	extension/pgmq--0.5.0.sql
	extension/pgmq.control
	manifest.json
Packaged to ./.trunk/pgmq-0.5.0.tar.gz
```
```
❯ tar tvf .trunk/pgmq-0.5.0.tar.gz
-rwxr-xr-x 0/0         2312992 2023-05-15 19:46 pgmq.so
-rw-r--r-- 0/0           11342 2023-05-15 19:46 LICENSE
-rw-r--r-- 0/0            3644 2023-05-15 19:46 extension/pgmq--0.5.0.sql
-rw-r--r-- 0/0             160 2023-05-15 19:46 extension/pgmq.control
-rw-r--r-- 0/0             365 1969-12-31 19:00 manifest.json
```
```
❯ cat manifest.json
{
  "name": "pgmq",
  "version": "0.5.0",
  "manifest_version": 2,
  "sys": "linux",
  "architecture": "x86_64",
  "files": {
    "extension/pgmq--0.5.0.sql": {
      "type": "sql-file"
    },
    "extension/pgmq.control": {
      "type": "control-file"
    },
    "LICENSE": {
      "type": "extra"
    },
    "pgmq.so": {
      "type": "shared-object"
    }
  }
}
```

This should pick up any files that match the following patterns:
```
{ name: "license", globs: ["*[.-]LICEN[CS]E*", "AGPL-*[0-9]*", "APACHE-*[0-9]*", "BSD-*[0-9]*", "CC-BY-*", "COPYING", "COPYING[.-]*", "COPYRIGHT", "COPYRIGHT[.-]*", "EULA", "EULA[.-]*", "GFDL-*[0-9]*", "GNU-*[0-9]*", "GPL-*[0-9]*", "LGPL-*[0-9]*", "LICEN[CS]E", "LICEN[CS]E[.-]*", "MIT-*[0-9]*", "MPL-*[0-9]*", "NOTICE", "NOTICE[.-]*", "OFL-*[0-9]*", "PATENTS", "PATENTS[.-]*", "UNLICEN[CS]E", "UNLICEN[CS]E[.-]*", "agpl[.-]*", "gpl[.-]*", "lgpl[.-]*", "licen[cs]e", "licen[cs]e.*"] }
```

If multiple license files are found with the same name, we append a numbered suffix to all duplicate filenames:
```
❯ tar -tvf pg_stat_statements-1.10.0.tar.gz
-rwxr-xr-x 0/0           52536 2023-05-15 19:28 pg_stat_statements.so
-rw-r--r-- 0/0            4362 2023-05-15 19:28 COPYRIGHT
-rw-r--r-- 0/0            1192 2023-05-15 19:28 COPYRIGHT.~1~
-rw-r--r-- 0/0            1246 2023-05-15 19:28 extension/pg_stat_statements--1.0--1.1.sql
-rw-r--r-- 0/0            1336 2023-05-15 19:28 extension/pg_stat_statements--1.1--1.2.sql
-rw-r--r-- 0/0            1454 2023-05-15 19:28 extension/pg_stat_statements--1.2--1.3.sql
-rw-r--r-- 0/0             345 2023-05-15 19:28 extension/pg_stat_statements--1.3--1.4.sql
-rw-r--r-- 0/0             305 2023-05-15 19:28 extension/pg_stat_statements--1.4--1.5.sql
-rw-r--r-- 0/0            1427 2023-05-15 19:28 extension/pg_stat_statements--1.4.sql
-rw-r--r-- 0/0             376 2023-05-15 19:28 extension/pg_stat_statements--1.5--1.6.sql
-rw-r--r-- 0/0             806 2023-05-15 19:28 extension/pg_stat_statements--1.6--1.7.sql
-rw-r--r-- 0/0            1744 2023-05-15 19:28 extension/pg_stat_statements--1.7--1.8.sql
-rw-r--r-- 0/0            2128 2023-05-15 19:28 extension/pg_stat_statements--1.8--1.9.sql
-rw-r--r-- 0/0            2114 2023-05-15 19:28 extension/pg_stat_statements--1.9--1.10.sql
-rw-r--r-- 0/0             205 2023-05-15 19:28 extension/pg_stat_statements.control
-rw-r--r-- 0/0            1315 1969-12-31 19:00 manifest.json
```

License files are skipped during `trunk install`:
```
Using pg_config: /usr/bin/pg_config
Using pkglibdir: "/usr/lib/postgresql/15/lib"
Using sharedir: "/usr/share/postgresql/15"
Dependencies: ["pg_partman"]
Installing pgmq 0.5.0
[+] pgmq.so => /usr/lib/postgresql/15/lib
Skipping license file licenses/LICENSE
[+] extension/pgmq--0.5.0.sql => /usr/share/postgresql/15
[+] extension/pgmq.control => /usr/share/postgresql/15
```