### PR TITLE
panic when API token not provided

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.4.8"
+version = "0.4.9"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/publish.rs
+++ b/cli/src/commands/publish.rs
@@ -67,7 +67,7 @@ impl SubCommand for PublishCommand {
         let mut headers = HeaderMap::new();
         headers.insert(CONTENT_TYPE, "application/octet-stream".parse().unwrap());
         // Add token header from env var
-        let auth = env::var("TRUNK_API_TOKEN").unwrap_or_else(|_| "".to_owned());
+        let auth = env::var("TRUNK_API_TOKEN").expect("TRUNK_API_TOKEN not set");
         headers.insert(AUTHORIZATION, auth.parse()?);
         let file_part = reqwest::multipart::Part::bytes(file)
             .file_name(name)


### PR DESCRIPTION
The publish operation cannot recover from a missing API token. Therefore, fail with a useful error message when that happens. I think in future there could be a more robust input validation and error message, following by some sort of graceful program exit, whenever there is invalid user input (such as a missing API token).