### PR TITLE
Build pgrx images for 0.8.3 and 0.8.4

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -31,6 +31,8 @@ jobs:
         pgrx_version:
           - "0.7.4"
           - "0.8.0"
+          - "0.8.3"
+          - "0.8.4"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3


### PR DESCRIPTION
Add PGRX 0.8.3 and 0.8.4 to the automated image build process.