### PR TITLE
Add support for pgrx 0.9.0 and 0.9.1

### DIFF
--- a/.github/workflows/images.yml
+++ b/.github/workflows/images.yml
@@ -33,6 +33,8 @@ jobs:
           - "0.8.0"
           - "0.8.3"
           - "0.8.4"
+          - "0.9.0"
+          - "0.9.1"
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pg-trunk"
-version = "0.5.1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Steven Miller", "Ian Stanton"]
 description = "A package manager for PostgreSQL extensions"

--- a/cli/src/commands/pgrx.rs
+++ b/cli/src/commands/pgrx.rs
@@ -54,7 +54,7 @@ pub enum PgrxBuildError {
 }
 
 fn semver_from_range(pgrx_range: &str) -> Result<String, PgrxBuildError> {
-    let versions = ["0.8.4", "0.8.3", "0.8.0", "0.7.4"];
+    let versions = ["0.9.1", "0.9.0", "0.8.4", "0.8.3", "0.8.0", "0.7.4"];
 
     if versions.contains(&pgrx_range) {
         // If the input is already a specific version, return it as-is
@@ -267,5 +267,7 @@ mod tests {
         // Test that a semver range is converted to the highest matching version
         let result = semver_from_range(">=0.8.0, <0.9.0");
         assert_eq!(result.unwrap(), "0.8.4");
+        let result = semver_from_range(">=0.9.0, <0.10.0");
+        assert_eq!(result.unwrap(), "0.9.1");
     }
 }


### PR DESCRIPTION
This PR adds support for building extensions written with PGRX `0.9.0` and `0.9.1`. 